### PR TITLE
Fix warning with newer GCC

### DIFF
--- a/haicrypt/hcrypt.c
+++ b/haicrypt/hcrypt.c
@@ -121,7 +121,6 @@ int HaiCrypt_Create(HaiCrypt_Cfg *cfg, HaiCrypt_Handle *phhc)
 	if (inbuf_siz) {
 		crypto->inbuf = mem_buf;
 		crypto->inbuf_siz = inbuf_siz;
-		mem_buf += inbuf_siz;
 	}
 
 	crypto->cipher = cfg->cipher;

--- a/srtcore/api.h
+++ b/srtcore/api.h
@@ -277,8 +277,8 @@ inline std::string SockaddrToString(const sockaddr* sadr)
         : 0;
 	// (cast to (void*) is required because otherwise the 2-3 arguments
 	// of ?: operator would have different types, which isn't allowed in C++.
-    if ( !addr )
-        return "unknown:0";
+        if ( !addr )
+            return "unknown:0";
 
 	std::ostringstream output;
 	char hostbuf[1024];

--- a/srtcore/core.cpp
+++ b/srtcore/core.cpp
@@ -4308,7 +4308,6 @@ int CUDT::packData(CPacket& packet, uint64_t& ts)
    {
       // sends out probing packet pair
       ts = entertime;
-      probe = false;
    }
    else
    {


### PR DESCRIPTION
The code has warnings when build with gcc 7.1.1 that is in Fedora 26. So the first patch fixes it, as it now complains about misleading indentation. The second patch is to fix some warnings found by clang-analyze, there were more, but they required more though so I ignored them...